### PR TITLE
Use org.kde.Sdk as runtime to get objdump

### DIFF
--- a/org.kde.kcachegrind.json
+++ b/org.kde.kcachegrind.json
@@ -1,6 +1,6 @@
 {
     "id": "org.kde.kcachegrind",
-    "runtime": "org.kde.Platform",
+    "runtime": "org.kde.Sdk",
     "runtime-version": "5.15-22.08",
     "sdk": "org.kde.Sdk",
     "command": "kcachegrind",


### PR DESCRIPTION
Kcachegrind is a development tool so using the Sdk as runtime seems reasonable.

Fixes: https://github.com/flathub/org.kde.kcachegrind/issues/65